### PR TITLE
add parameters when getting project labels

### DIFF
--- a/lib/Gitlab/Api/Projects.php
+++ b/lib/Gitlab/Api/Projects.php
@@ -493,11 +493,14 @@ class Projects extends AbstractApi
 
     /**
      * @param int $project_id
+     * @param array $parameters
      * @return mixed
      */
-    public function labels($project_id)
+    public function labels($project_id, array $parameters = [])
     {
-        return $this->get($this->getProjectPath($project_id, 'labels'));
+        $resolver = $this->createOptionsResolver();
+
+        return $this->get($this->getProjectPath($project_id, 'labels'), $resolver->resolve($parameters));
     }
 
     /**


### PR DESCRIPTION
Couldn't get all the labels of a project due to the default limit of 20 per page.
Now we can pass optional paramaters to get project labels
ex: $parameters = ['page'=>1, 'per_page'=>100];