### PR TITLE
add crud methods to issue boards

### DIFF
--- a/lib/Gitlab/Api/IssueBoards.php
+++ b/lib/Gitlab/Api/IssueBoards.php
@@ -22,6 +22,47 @@ class IssueBoards extends AbstractApi
      * @param int $board_id
      * @return mixed
      */
+    public function show($project_id, $board_id)
+    {
+        return $this->get($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $project_id
+     * @param array $params
+     * @return mixed
+     */
+    public function create($project_id, array $params)
+    {
+        return $this->post($this->getProjectPath($project_id, 'boards'), $params);
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @param array $params
+     * @return mixed
+     */
+    public function update($project_id, $board_id, array $params)
+    {
+        return $this->put($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)), $params);
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @return mixed
+     */
+    public function remove($project_id, $board_id)
+    {
+        return $this->delete($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id)));
+    }
+
+    /**
+     * @param int $project_id
+     * @param int $board_id
+     * @return mixed
+     */
     public function allLists($project_id, $board_id)
     {
         return $this->get($this->getProjectPath($project_id, 'boards/'.$this->encodePath($board_id).'/lists'));


### PR DESCRIPTION
These 4 methods were missing from the IssueBoards class:
- show (https://docs.gitlab.com/ee/api/boards.html#single-board)
- create (https://docs.gitlab.com/ee/api/boards.html#create-a-board)
- update (https://docs.gitlab.com/ee/api/boards.html#update-a-board)
- remove (https://docs.gitlab.com/ee/api/boards.html#delete-a-board)
